### PR TITLE
block and timestamp properties removed

### DIFF
--- a/test/graph.js
+++ b/test/graph.js
@@ -7,8 +7,6 @@ describe('graphs', () => {
     'tokenDetails.tokenIdHex',
     'graphTxn',
     'graphTxn.txid',
-    'graphTxn.timestamp',
-    'graphTxn.block',
     'graphTxn.details',
     'graphTxn.details.decimals',
     'graphTxn.details.tokenIdHex',


### PR DESCRIPTION
These were removed from the graphs collection since it exists within the confirmed collection.